### PR TITLE
[Feat] DB에 S3 key 저장

### DIFF
--- a/back/photorize/src/main/java/com/shutter/photorize/domain/file/service/FileService.java
+++ b/back/photorize/src/main/java/com/shutter/photorize/domain/file/service/FileService.java
@@ -25,7 +25,7 @@ public class FileService {
 	public void saveFile(MultipartFile file, Memory memory) {
 		String extension = getFileExtension(file);
 		FileType type = FileType.fromExtension(extension);
-		String s3Key = s3Utils.generateS3Key(file, type);
+		String s3Key = s3Utils.generateS3Key(type);
 
 		s3Utils.uploadToS3(file, s3Key)
 			.thenAccept(url -> {

--- a/back/photorize/src/main/java/com/shutter/photorize/global/util/S3Utils.java
+++ b/back/photorize/src/main/java/com/shutter/photorize/global/util/S3Utils.java
@@ -76,8 +76,7 @@ public class S3Utils {
 				RequestBody.fromBytes(file.getBytes())
 			);
 
-			String url = String.format(s3Url, bucket, region, s3Key);
-			return CompletableFuture.completedFuture(url);
+			return CompletableFuture.completedFuture(s3Key);
 		} catch (IOException e) {
 			throw new PhotorizeException(ErrorType.FILE_UPLOAD_ERROR);
 		}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 입력해주세요.  
> **예시**: `#12`, `#34`
Closes #11
---

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.  
- 기존 S3 객체의 전체 URL을 DB에 저장하던 방식에서 S3 Key만 저장하도록 변경
- 기존 S3 Key 생성 로직 수정
  -  원본 파일명을 포함하지 않고 UUID 기반의 Key만 생성하도록 변경
---

## 💬 리뷰 요구사항 (선택)

> 리뷰어에게 특별히 확인받고 싶은 사항이 있다면 작성해주세요.  
> **예시**: 
> - 메서드 이름을 더 명확하게 짓고 싶습니다.
> - 코드가 반복되는데 리팩토링 아이디어가 있을까요?
