### PR TITLE
Feat: 추억 응답 DTO에 memoryId, spotId 추가

### DIFF
--- a/back/photorize/src/main/java/com/shutter/photorize/domain/memory/dto/response/MemoryDetailResponse.java
+++ b/back/photorize/src/main/java/com/shutter/photorize/domain/memory/dto/response/MemoryDetailResponse.java
@@ -14,33 +14,39 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemoryDetailResponse {
 
+	private Long memoryId;
 	private Long writerId;
 	private String nickname;
 	private String writerImg;
 	private List<FileResponse> files;
 	private LocalDate date;
+	private Long spotId;
 	private String spotName;
 	private String content;
 
 	@Builder
-	private MemoryDetailResponse(Long writerId, String nickname, String writerImg, List<FileResponse> files, LocalDate date,
-		String spotName, String content) {
+	private MemoryDetailResponse(Long memoryId, Long writerId, String nickname, String writerImg,
+		List<FileResponse> files, LocalDate date, Long spotId, String spotName, String content) {
+		this.memoryId = memoryId;
 		this.writerId = writerId;
 		this.nickname = nickname;
 		this.writerImg = writerImg;
 		this.files = files;
 		this.date = date;
+		this.spotId = spotId;
 		this.spotName = spotName;
 		this.content = content;
 	}
 
 	public static MemoryDetailResponse of(Memory memory, List<FileResponse> files) {
 		return MemoryDetailResponse.builder()
+			.memoryId(memory.getId())
 			.writerId(memory.getMember().getId())
 			.nickname(memory.getMember().getNickname())
 			.writerImg(memory.getMember().getImg())
 			.files(files)
 			.date(LocalDate.from(memory.getDate()))
+			.spotId(memory.getSpot().getId())
 			.spotName(memory.getSpot().getName())
 			.content(memory.getContent())
 			.build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 입력해주세요.  
> **예시**: `#12`, `#34`
Closes #21 
---

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.  

- `MemoryDetailResponse` DTO에 `memoryId`, `spotId` 필드 추가
- `.of()` 메서드에서 각각 `memory.getId()`, `memory.getSpot().getId()` 값 설정
- 응답 객체에서 두 ID 필드가 정상적으로 포함되는지 테스트

---

## 💬 리뷰 요구사항 (선택)

> 리뷰어에게 특별히 확인받고 싶은 사항이 있다면 작성해주세요.  
> **예시**: 
> - 메서드 이름을 더 명확하게 짓고 싶습니다.
> - 코드가 반복되는데 리팩토링 아이디어가 있을까요?
