### PR TITLE
Refactor: 빌드 캐싱 최적화 및 이미지 용량 축소를 위한 Dockerfile 개선

### DIFF
--- a/back/photorize/Dockerfile
+++ b/back/photorize/Dockerfile
@@ -1,34 +1,29 @@
 # Stage 1: Build the application
 FROM gradle:8.10.2-jdk17 AS build
-
-# Set the working directory for the build stage
 WORKDIR /app
 
-# Copy all project files
+# Optimize caching by copying build files first
+COPY gradlew /app/gradlew
+COPY gradle /app/gradle
+COPY build.gradle settings.gradle /app/
+RUN ./gradlew build -x test --no-daemon || return 0
+
+# Now copy the rest of the source code
 COPY . /app
-
-# Copy the Gradle wrapper and build files
-COPY ./gradlew /app/gradlew
-COPY ./gradle /app/gradle
-COPY ./build.gradle settings.gradle /app/
-
-# Run the Gradle build (this will produce the JAR file in build/libs)
 RUN ./gradlew clean build -x test
 
 # Stage 2: Create the final image
 FROM openjdk:17-jdk-slim
-
-# Set the working directory for the final image
 WORKDIR /app
 
-# Install tzdata and set timezone to Asia/Seoul
+# Install tzdata and clean up
 RUN apt-get update && apt-get install -y tzdata && \
     ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
     echo "Asia/Seoul" > /etc/timezone && \
-    apt-get clean
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy the JAR file from the build stage
 COPY --from=build /app/build/libs/photorize-0.0.1-SNAPSHOT.jar app.jar
 
-# Run the application with the server profile activated
+# Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 입력해주세요.  
> **예시**: `#12`, `#34`
몰랑~~

---

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.  
서버 배포 시 사용되는 Dockerfile 중 불필요하게 빌드 과정에서 캐시를 저장하는 부분을 수정했습니당
---

## 💬 리뷰 요구사항 (선택)

> 리뷰어에게 특별히 확인받고 싶은 사항이 있다면 작성해주세요.  
> **예시**: 
> - 메서드 이름을 더 명확하게 짓고 싶습니다.
> - 코드가 반복되는데 리팩토링 아이디어가 있을까요?

리뷰하지마!!!